### PR TITLE
Update histograms/no_cardinality/metrics benchmark to use pre-resolved handle.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -748,9 +748,9 @@ dependencies = [
 
 [[package]]
 name = "metrics-exporter-prometheus"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26eb45aff37b45cff885538e1dcbd6c2b462c04fe84ce0155ea469f325672c98"
+checksum = "bf0af7a0d7ced10c0151f870e5e3f3f8bc9ffc5992d32873566ca1f9169ae776"
 dependencies = [
  "base64",
  "indexmap",

--- a/README.md
+++ b/README.md
@@ -42,19 +42,19 @@ counters              fastest       │ slowest       │ median        │ mean
 #### Linux Ryzen 9 7950x (32 Threads)
 
 ```
-Timer precision: 2.36 µs
+Timer precision: 10 ns
 histograms               fastest       │ slowest       │ median        │ mean          │ samples │ iters
 ├─ fixed_cardinality                   │               │               │               │         │
-│  ├─ measured           296 ns        │ 464.6 ns      │ 380.6 ns      │ 381.1 ns      │ 512     │ 51200000
-│  ├─ measured_sparse    457.1 ns      │ 621.2 ns      │ 523.4 ns      │ 522 ns        │ 512     │ 51200000
-│  ├─ metrics            4.146 µs      │ 4.867 µs      │ 4.314 µs      │ 4.346 µs      │ 512     │ 51200000
-│  ├─ prometheus         1.43 µs       │ 1.872 µs      │ 1.525 µs      │ 1.546 µs      │ 512     │ 51200000
-│  ╰─ prometheus_client  2.196 µs      │ 2.753 µs      │ 2.551 µs      │ 2.549 µs      │ 512     │ 51200000
+│  ├─ measured           212.4 ns      │ 402.9 ns      │ 346.6 ns      │ 342.5 ns      │ 512     │ 51200000
+│  ├─ measured_sparse    382.5 ns      │ 586.6 ns      │ 510 ns        │ 506.3 ns      │ 512     │ 51200000
+│  ├─ metrics            745.5 ns      │ 998.9 ns      │ 847.1 ns      │ 848.7 ns      │ 512     │ 51200000
+│  ├─ prometheus         1.509 µs      │ 1.779 µs      │ 1.662 µs      │ 1.654 µs      │ 512     │ 51200000
+│  ╰─ prometheus_client  1.701 µs      │ 2.556 µs      │ 2.442 µs      │ 2.413 µs      │ 512     │ 51200000
 ╰─ no_cardinality                      │               │               │               │         │
-   ├─ measured           7.211 µs      │ 12.88 µs      │ 7.283 µs      │ 7.685 µs      │ 512     │ 51200000
-   ├─ metrics            11.68 µs      │ 12.67 µs      │ 11.81 µs      │ 11.89 µs      │ 512     │ 51200000
-   ├─ prometheus         7.202 µs      │ 8.017 µs      │ 7.322 µs      │ 7.362 µs      │ 512     │ 51200000
-   ╰─ prometheus_client  109.5 µs      │ 113.1 µs      │ 111.4 µs      │ 111.4 µs      │ 512     │ 51200000
+   ├─ measured           2.8 µs        │ 3.532 µs      │ 3.331 µs      │ 3.264 µs      │ 512     │ 51200000
+   ├─ metrics            1.072 µs      │ 1.328 µs      │ 1.204 µs      │ 1.201 µs      │ 512     │ 51200000
+   ├─ prometheus         2.645 µs      │ 3.531 µs      │ 3.242 µs      │ 3.21 µs       │ 512     │ 51200000
+   ╰─ prometheus_client  22.61 µs      │ 23.15 µs      │ 23 µs         │ 22.97 µs      │ 512     │ 51200000
 ```
 
 #### Macbook Pro M2 Max (12 Threads)

--- a/README.md
+++ b/README.md
@@ -63,16 +63,16 @@ histograms               fastest       │ slowest       │ median        │ m
 Timer precision: 41 ns
 histograms               fastest       │ slowest       │ median        │ mean          │ samples │ iters
 ├─ fixed_cardinality                   │               │               │               │         │
-│  ├─ measured           325.1 ns      │ 433.4 ns      │ 417.7 ns      │ 414.4 ns      │ 504     │ 50400000
-│  ├─ measured_sparse    503.3 ns      │ 690 ns        │ 580.1 ns      │ 579.6 ns      │ 504     │ 50400000
-│  ├─ metrics            1.147 µs      │ 1.462 µs      │ 1.275 µs      │ 1.275 µs      │ 504     │ 50400000
-│  ├─ prometheus         4.055 µs      │ 4.297 µs      │ 4.247 µs      │ 4.235 µs      │ 504     │ 50400000
-│  ╰─ prometheus_client  3.913 µs      │ 4.186 µs      │ 4.14 µs       │ 4.129 µs      │ 504     │ 50400000
+│  ├─ measured           132.8 ns      │ 444 ns        │ 409.6 ns      │ 401.3 ns      │ 504     │ 50400000
+│  ├─ measured_sparse    320.9 ns      │ 565.4 ns      │ 492.9 ns      │ 491.1 ns      │ 504     │ 50400000
+│  ├─ metrics            1.064 µs      │ 1.43 µs       │ 1.258 µs      │ 1.256 µs      │ 504     │ 50400000
+│  ├─ prometheus         3.2 µs        │ 4.248 µs      │ 4.181 µs      │ 4.142 µs      │ 504     │ 50400000
+│  ╰─ prometheus_client  2.799 µs      │ 4.5 µs        │ 4.387 µs      │ 4.302 µs      │ 504     │ 50400000
 ╰─ no_cardinality                      │               │               │               │         │
-   ├─ measured           4.829 µs      │ 5.187 µs      │ 5.133 µs      │ 5.122 µs      │ 504     │ 50400000
-   ├─ metrics            5.753 µs      │ 7.257 µs      │ 6.971 µs      │ 6.937 µs      │ 504     │ 50400000
-   ├─ prometheus         4.639 µs      │ 5.309 µs      │ 5.125 µs      │ 5.108 µs      │ 504     │ 50400000
-   ╰─ prometheus_client  2.092 µs      │ 2.471 µs      │ 2.352 µs      │ 2.344 µs      │ 504     │ 50400000
+   ├─ measured           3.636 µs      │ 7.291 µs      │ 7.143 µs      │ 6.945 µs      │ 504     │ 50400000
+   ├─ metrics            1.733 µs      │ 2.053 µs      │ 2 µs          │ 1.988 µs      │ 504     │ 50400000
+   ├─ prometheus         1.81 µs       │ 5.23 µs       │ 5.121 µs      │ 4.882 µs      │ 504     │ 50400000
+   ╰─ prometheus_client  1.813 µs      │ 2.271 µs      │ 2.194 µs      │ 2.169 µs      │ 504     │ 50400000
 ```
 
 ### Memory

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -37,7 +37,7 @@ fake = "2.9.2"
 divan = "0.1.14"
 prometheus = { version = "0.13.3", default-features = false }
 metrics = "0.23.0"
-metrics-exporter-prometheus = { version = "0.15.0", default-features = false }
+metrics-exporter-prometheus = { version = "0.15.1", default-features = false }
 prometheus-client = "0.22.2"
 rand = { version = "0.8", features = ["small_rng"] }
 phf = { version = "0.11", features = ["macros"] }

--- a/core/benches/histograms.rs
+++ b/core/benches/histograms.rs
@@ -247,15 +247,14 @@ mod no_cardinality {
             .unwrap()
             .build_recorder();
 
-        metrics::with_local_recorder(&recorder, || {
+        let h = metrics::with_local_recorder(&recorder, || {
             metrics::describe_histogram!("http_request_errors", "help text");
+            metrics::histogram!("http_request_errors")
         });
 
         bencher.bench(|| {
-            metrics::with_local_recorder(&recorder, || {
-                let start = Instant::now();
-                metrics::histogram!("http_request_errors").record(start.elapsed().as_secs_f64());
-            });
+            let start = Instant::now();
+            h.record(start.elapsed().as_secs_f64());
         });
     }
 


### PR DESCRIPTION
For the aforementioned benchmark, this PR switches to using a pre-registered handle. Pre-registered handles are fairly common for super performance-sensitive use cases, so it's a no-brainer to use them when there's no dynamic labels involved... and will naturally be faster than re-registering the metric each time.