### PR TITLE
Fix docsrs build (bandaid)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -634,11 +634,10 @@ checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "lock_api"
-version = "0.4.11"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,7 +1,7 @@
 //! # Measured. A low-overhead prometheus/metrics crate for measuring your application statistics.
 //!
 //! Getting started? See [`docs`]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(
     clippy::cast_precision_loss,
     clippy::cast_possible_wrap,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! Getting started? See [`docs`]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, doc(auto_cfg))]
 #![allow(
     clippy::cast_precision_loss,
     clippy::cast_possible_wrap,


### PR DESCRIPTION
This fixes builds on docsrs with the most bandaid solution available (replacing doc_auto_cfg with doc_cfg and relocking lock_api to a new version)

I don't know if this keeps the docs correct in regards to annotations of cfg, but it does make any docs exist at all.
