### PR TITLE
introduce global registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -143,6 +143,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26c4925bc979b677330a8c7fe7a8c94af2dbb4a2d37b4a20a80d884400f46baa"
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -222,6 +233,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
+name = "ctor"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -262,7 +283,7 @@ checksum = "27540baf49be0d484d8f0130d7d8da3011c32a44d4fc873368154f1510e574a2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -409,6 +430,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghost"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1323e4e10ffd5d48a21ea37f8d4e3b15dd841121d1301a86122fa0984bedf0a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,12 +484,6 @@ dependencies = [
  "equivalent",
  "foldhash",
 ]
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -572,12 +598,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.10.5"
+name = "inventory"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "f0eb5160c60ba1e809707918ee329adb99d222888155835c6feedba19f6c3fd4"
 dependencies = [
- "either",
+ "ctor",
+ "ghost",
+ "inventory-impl",
+]
+
+[[package]]
+name = "inventory-impl"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e41b53715c6f0c4be49510bb82dee2c1e51c8586d885abe65396e82ed518548"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -685,10 +724,10 @@ dependencies = [
 name = "measured-derive"
 version = "0.0.24"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -717,6 +756,16 @@ dependencies = [
  "prost-types",
  "rand 0.8.5",
  "ryu",
+]
+
+[[package]]
+name = "measured-registry"
+version = "0.0.24"
+dependencies = [
+ "bstr",
+ "bytes",
+ "inventory",
+ "measured",
 ]
 
 [[package]]
@@ -893,7 +942,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -922,7 +971,7 @@ checksum = "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -966,7 +1015,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff24dfcda44452b9816fff4cd4227e1bb73ff5a2f1bc1105aa92fb8565ce44d2"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1039,7 +1088,7 @@ checksum = "9adf1691c04c0a5ff46ff8f262b58beb07b0dbb61f96f9f54f6cbd82106ed87f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1059,8 +1108,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80b776a1b2dc779f5ee0641f8ade0125bc1298dd41a9a0c16d8bd57b42d222b1"
 dependencies = [
  "bytes",
- "heck 0.4.1",
- "itertools 0.10.5",
+ "heck",
+ "itertools",
  "log",
  "multimap",
  "once_cell",
@@ -1069,7 +1118,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn",
+ "syn 2.0.104",
  "tempfile",
 ]
 
@@ -1080,10 +1129,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9554e3ab233f0a932403704f1a1d08c30d5ccd931adfdfa1e8b5a19b52c1d55a"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1326,7 +1375,7 @@ checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1420,6 +1469,17 @@ dependencies = [
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
@@ -1489,7 +1549,7 @@ checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1500,7 +1560,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1528,7 +1588,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1647,7 +1707,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
  "wasm-bindgen-shared",
 ]
 
@@ -1669,7 +1729,7 @@ checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1975,5 +2035,5 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,6 @@ members = [
     "examples/*",
     "tokio",
     "prometheus-proto",
+    "registry",
 ]
 resolver = "2"

--- a/core/src/metric.rs
+++ b/core/src/metric.rs
@@ -156,6 +156,15 @@ impl<M: MetricType> Metric<M> {
     }
 }
 
+impl super::Counter {
+    pub const fn const_new() -> Self {
+        Self {
+            metric: counter::CounterState::new(0),
+            metadata: (),
+        }
+    }
+}
+
 fn new_dense<M: MetricType>(c: usize) -> Box<[CachePadded<OnceLock<M>>]> {
     let mut vec = Vec::with_capacity(c);
     vec.resize_with(c, CachePadded::<OnceLock<M>>::default);

--- a/core/src/metric.rs
+++ b/core/src/metric.rs
@@ -4,7 +4,7 @@ use core::hash::Hash;
 use std::{
     hash::BuildHasher,
     ops::{Deref, DerefMut},
-    sync::OnceLock,
+    sync::{LazyLock, OnceLock},
 };
 
 use crate::label::{LabelGroup, LabelGroupSet, NoLabels};
@@ -436,6 +436,24 @@ impl<M: MetricFamilyEncoding<T>, T: Encoding> MetricFamilyEncoding<T> for Option
         if let Some(this) = self {
             this.collect_family_into(name, enc)?;
         }
+        Ok(())
+    }
+}
+
+impl<M: MetricFamilyEncoding<T>, T: Encoding> MetricFamilyEncoding<T> for OnceLock<M> {
+    fn collect_family_into(&self, name: impl MetricNameEncoder, enc: &mut T) -> Result<(), T::Err> {
+        if let Some(this) = self.get() {
+            this.collect_family_into(name, enc)?;
+        }
+        Ok(())
+    }
+}
+
+impl<M: MetricFamilyEncoding<T>, T: Encoding> MetricFamilyEncoding<T> for LazyLock<M> {
+    fn collect_family_into(&self, name: impl MetricNameEncoder, enc: &mut T) -> Result<(), T::Err> {
+        // fixme: use LazyLock::get when stable
+        LazyLock::force(self).collect_family_into(name, enc)?;
+
         Ok(())
     }
 }

--- a/core/src/metric/counter.rs
+++ b/core/src/metric/counter.rs
@@ -21,7 +21,7 @@ pub type CounterLockGuard<'a> = MetricLockGuard<'a, CounterState>;
 pub type CounterMut<'a> = MetricMut<'a, CounterState>;
 
 impl CounterState {
-    pub fn new(value: u64) -> Self {
+    pub const fn new(value: u64) -> Self {
         Self {
             count: AtomicU64::new(value),
         }

--- a/core/src/metric/gauge.rs
+++ b/core/src/metric/gauge.rs
@@ -16,7 +16,7 @@ pub struct GaugeState {
 }
 
 impl GaugeState {
-    pub fn new(value: i64) -> Self {
+    pub const fn new(value: i64) -> Self {
         Self {
             count: AtomicI64::new(value),
         }
@@ -168,7 +168,7 @@ pub struct FloatGaugeState {
 }
 
 impl FloatGaugeState {
-    pub fn new(value: f64) -> Self {
+    pub const fn new(value: f64) -> Self {
         Self {
             count: AtomicF64::new(value),
         }
@@ -310,7 +310,7 @@ impl AtomicF64 {
         inner: AtomicU64::new(0),
     };
 
-    pub fn new(val: f64) -> AtomicF64 {
+    pub const fn new(val: f64) -> AtomicF64 {
         AtomicF64 {
             inner: AtomicU64::new(val.to_bits()),
         }

--- a/registry/Cargo.toml
+++ b/registry/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "measured-registry"
+version = "0.0.24"
+edition = "2024"
+description = "Global registry for measured"
+authors = ["Conrad Ludgate <conradludgate@gmail.com"]
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/conradludgate/measured"
+readme = "../README.md"
+rust-version = "1.88"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[features]
+
+[dependencies]
+measured = { path = "../core", version = "0.0.24" }
+inventory = "0.1"
+
+[dev-dependencies]
+bytes = "1"
+bstr = "1"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/registry/src/lib.rs
+++ b/registry/src/lib.rs
@@ -87,11 +87,24 @@ mod tests {
     #[test]
     fn test_http_requests() {
         http_requests.inc();
+        http_requests.inc();
+        http_errors.inc();
 
+        let metrics = encode();
+
+        check_sections(metrics, &[
+            b"# HELP http_errors The number of HTTP errors\n# TYPE http_errors counter\nhttp_errors 1\n",
+            b"# HELP http_requests The number of HTTP requests\n# TYPE http_requests counter\nhttp_requests 2\n",
+        ]);
+    }
+
+    fn encode() -> Bytes {
         let mut text_encoder = BufferedTextEncoder::new();
         let Ok(()) = GlobalRegistry.collect_group_into(&mut text_encoder);
-        let mut bytes = text_encoder.finish();
+        text_encoder.finish()
+    }
 
+    fn check_sections(mut bytes: Bytes, expected: &[&'static [u8]]) {
         let mut sections = Vec::new();
         while let Some(pos) = bytes.find(b"\n\n") {
             sections.push(bytes.split_to(pos + 1));
@@ -99,17 +112,10 @@ mod tests {
         }
         sections.push(bytes);
 
-        let expected_errors = Bytes::from_static(b"# HELP http_errors The number of HTTP errors\n# TYPE http_errors counter\nhttp_errors 0\n");
-        let expected_requests = Bytes::from_static(b"# HELP http_requests The number of HTTP requests\n# TYPE http_requests counter\nhttp_requests 1\n");
-
-        assert_eq!(sections.len(), 2);
-        assert!(
-            sections.contains(&expected_errors),
-            "sections: {sections:?}",
-        );
-        assert!(
-            sections.contains(&expected_requests),
-            "sections: {sections:?}",
-        );
+        assert_eq!(sections.len(), expected.len());
+        for e in expected {
+            let e = Bytes::from_static(e);
+            assert!(sections.contains(&e), "sections: {sections:?}");
+        }
     }
 }

--- a/registry/src/lib.rs
+++ b/registry/src/lib.rs
@@ -50,7 +50,8 @@ macro_rules! metric {
     };
 }
 
-pub struct GlobalRegistry;
+#[derive(Default, Clone)]
+pub struct GlobalRegistry(());
 
 impl MetricGroup<BufferedTextEncoder> for GlobalRegistry {
     fn collect_group_into(&self, enc: &mut BufferedTextEncoder) -> Result<(), Infallible> {
@@ -80,6 +81,13 @@ mod tests {
         pub static http_errors: measured::Counter = measured::Counter::const_new();
     );
 
+    #[derive(MetricGroup)]
+    #[metric(new())]
+    struct MyMetrics {
+        #[metric(flatten)]
+        global: GlobalRegistry,
+    }
+
     #[test]
     fn test_http_requests() {
         http_requests.inc();
@@ -96,7 +104,7 @@ mod tests {
 
     fn encode() -> Bytes {
         let mut text_encoder = BufferedTextEncoder::new();
-        let Ok(()) = GlobalRegistry.collect_group_into(&mut text_encoder);
+        let Ok(()) = MyMetrics::new().collect_group_into(&mut text_encoder);
         text_encoder.finish()
     }
 

--- a/registry/src/lib.rs
+++ b/registry/src/lib.rs
@@ -24,7 +24,7 @@ impl<M: MetricFamilyEncoding<BufferedTextEncoder>> MetricEncoding for M {
 
 pub struct Metric {
     name: &'static MetricName,
-    description: &'static str,
+    description: Option<&'static str>,
     metric: &'static dyn MetricEncoding,
 }
 
@@ -33,17 +33,21 @@ inventory::collect!(Metric);
 #[macro_export]
 macro_rules! metric {
     ($(
-        #[doc = $doc:literal]
+        $(#[doc = $doc:literal])?
         $vis:vis static $name:ident: $ty:ty = $value:expr;
     )*) => {
         $(
-            #[doc = $doc]
+            $(#[doc = $doc])?
             #[allow(non_upper_case_globals)]
             $vis static $name: $ty = $value;
 
             $crate::__private::submit!($crate::Metric {
                 name: $crate::__private::MetricName::from_str(stringify!($name)),
-                description: $doc.trim(),
+                description: 'desc: {
+                    $(break 'desc Some($doc.trim());)?
+                    #[allow(unreachable_code)]
+                    None
+                },
                 metric: &$name,
             });
         )*
@@ -55,7 +59,9 @@ pub struct GlobalRegistry;
 impl MetricGroup<BufferedTextEncoder> for GlobalRegistry {
     fn collect_group_into(&self, enc: &mut BufferedTextEncoder) -> Result<(), Infallible> {
         for metric in inventory::iter::<Metric> {
-            enc.write_help(metric.name, metric.description)?;
+            if let Some(desc) = metric.description {
+                enc.write_help(metric.name, desc)?;
+            }
             metric.metric.collect_family_into(metric.name, enc);
         }
         Ok(())

--- a/registry/src/lib.rs
+++ b/registry/src/lib.rs
@@ -1,0 +1,109 @@
+use std::convert::Infallible;
+
+use measured::{
+    MetricGroup,
+    metric::{MetricFamilyEncoding, group::Encoding, name::MetricName},
+    text::BufferedTextEncoder,
+};
+
+#[doc(hidden)]
+pub mod __private {
+    pub use inventory::submit;
+    pub use measured::metric::name::MetricName;
+}
+
+trait MetricEncoding {
+    fn collect_family_into(&self, name: &'static MetricName, enc: &mut BufferedTextEncoder);
+}
+
+impl<M: MetricFamilyEncoding<BufferedTextEncoder>> MetricEncoding for M {
+    fn collect_family_into(&self, name: &'static MetricName, enc: &mut BufferedTextEncoder) {
+        let Ok(()) = self.collect_family_into(name, enc);
+    }
+}
+
+pub struct Metric {
+    name: &'static MetricName,
+    description: &'static str,
+    metric: &'static dyn MetricEncoding,
+}
+
+inventory::collect!(Metric);
+
+#[macro_export]
+macro_rules! metric {
+    ($(
+        #[doc = $doc:literal]
+        $vis:vis static $name:ident: $ty:ty = $value:expr;
+    )*) => {
+        $(
+            #[doc = $doc]
+            #[allow(non_upper_case_globals)]
+            $vis static $name: $ty = $value;
+
+            $crate::__private::submit!($crate::Metric {
+                name: $crate::__private::MetricName::from_str(stringify!($name)),
+                description: $doc.trim(),
+                metric: &$name,
+            });
+        )*
+    };
+}
+
+pub struct GlobalRegistry;
+
+impl MetricGroup<BufferedTextEncoder> for GlobalRegistry {
+    fn collect_group_into(&self, enc: &mut BufferedTextEncoder) -> Result<(), Infallible> {
+        for metric in inventory::iter::<Metric> {
+            enc.write_help(metric.name, metric.description)?;
+            metric.metric.collect_family_into(metric.name, enc);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{GlobalRegistry, metric};
+    use measured::{MetricGroup, text::BufferedTextEncoder};
+
+    use bstr::ByteSlice;
+    use bytes::{Buf, Bytes};
+
+    metric!(
+        /// The number of HTTP requests
+        pub static http_requests: measured::Counter = measured::Counter::const_new();
+
+        /// The number of HTTP errors
+        pub static http_errors: measured::Counter = measured::Counter::const_new();
+    );
+
+    #[test]
+    fn test_http_requests() {
+        http_requests.inc();
+
+        let mut text_encoder = BufferedTextEncoder::new();
+        let Ok(()) = GlobalRegistry.collect_group_into(&mut text_encoder);
+        let mut bytes = text_encoder.finish();
+
+        let mut sections = Vec::new();
+        while let Some(pos) = bytes.find(b"\n\n") {
+            sections.push(bytes.split_to(pos + 1));
+            bytes.advance(1); // skip the newline
+        }
+        sections.push(bytes);
+
+        let expected_errors = Bytes::from_static(b"# HELP http_errors The number of HTTP errors\n# TYPE http_errors counter\nhttp_errors 0\n");
+        let expected_requests = Bytes::from_static(b"# HELP http_requests The number of HTTP requests\n# TYPE http_requests counter\nhttp_requests 1\n");
+
+        assert_eq!(sections.len(), 2);
+        assert!(
+            sections.contains(&expected_errors),
+            "sections: {sections:?}",
+        );
+        assert!(
+            sections.contains(&expected_requests),
+            "sections: {sections:?}",
+        );
+    }
+}

--- a/registry/src/lib.rs
+++ b/registry/src/lib.rs
@@ -33,7 +33,7 @@ inventory::collect!(Metric);
 #[macro_export]
 macro_rules! metric {
     ($(
-        $(#[doc = $doc:literal])?
+        $(#[doc = $doc:expr])?
         $vis:vis static $name:ident: $ty:ty = $value:expr;
     )*) => {
         $(
@@ -43,11 +43,7 @@ macro_rules! metric {
 
             $crate::__private::submit!($crate::Metric {
                 name: $crate::__private::MetricName::from_str(stringify!($name)),
-                description: 'desc: {
-                    $(break 'desc Some($doc.trim());)?
-                    #[allow(unreachable_code)]
-                    None
-                },
+                description: ($(Some($doc.trim()),)? None::<&'static str>,).0,
                 metric: &$name,
             });
         )*


### PR DESCRIPTION
The existing registry impl is quite a lot of boilerplate. While I prefer the concept of having properly scoped metrics, for an application it's easier to just register them when needed.