### PR TITLE
Add MIME_TYPE to Encoding for convenience (derived from prometheus spec)

### DIFF
--- a/core/src/metric/group.rs
+++ b/core/src/metric/group.rs
@@ -21,12 +21,19 @@ pub trait Encoding {
     /// The error type that this type might produce when encoding metric values.
     type Err;
 
+    /// The prometheus Content-Type that this Encoding exports as
+    /// https://prometheus.io/docs/instrumenting/content_negotiation/#protocol-headers
+    const MIME_TYPE: &'static str;
+
     /// Write the help text for a metric
     fn write_help(&mut self, name: impl MetricNameEncoder, help: &str) -> Result<(), Self::Err>;
 }
 
 impl<E: Encoding> Encoding for &mut E {
     type Err = E::Err;
+
+    const MIME_TYPE: &'static str = E::MIME_TYPE;
+
     fn write_help(&mut self, name: impl MetricNameEncoder, help: &str) -> Result<(), Self::Err> {
         E::write_help(self, name, help)
     }
@@ -91,6 +98,9 @@ impl<M: MetricGroup<T>, T: Encoding> MetricGroup<T> for Arc<M> {
 
 impl<E: Encoding> Encoding for WithNamespace<E> {
     type Err = E::Err;
+
+    const MIME_TYPE: &'static str = E::MIME_TYPE;
+
     fn write_help(&mut self, name: impl MetricNameEncoder, help: &str) -> Result<(), Self::Err> {
         self.inner.write_help(
             WithNamespace {

--- a/core/src/text.rs
+++ b/core/src/text.rs
@@ -51,6 +51,8 @@ pub enum MetricType {
 impl<W: Write> Encoding for TextEncoder<W> {
     type Err = std::io::Error;
 
+    const MIME_TYPE: &'static str = "text/plain; version=0.0.4";
+
     /// Write the help line for a metric
     fn write_help(
         &mut self,
@@ -356,6 +358,8 @@ impl<T, E: std::fmt::Debug> Unreachable<T> for Result<T, E> {
 
 impl Encoding for BufferedTextEncoder {
     type Err = Infallible;
+
+    const MIME_TYPE: &'static str = TextEncoder::<BytesWriter>::MIME_TYPE;
 
     /// Write the help line for a metric
     fn write_help(&mut self, name: impl MetricNameEncoder, help: &str) -> Result<(), Infallible> {

--- a/prometheus-proto/src/lib.rs
+++ b/prometheus-proto/src/lib.rs
@@ -86,6 +86,8 @@ pub enum MetricType {
 impl<W: Write> Encoding for ProtoEncoder<W> {
     type Err = std::io::Error;
 
+    const MIME_TYPE: &'static str = "application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited";
+
     /// Write the help line for a metric
     fn write_help(
         &mut self,


### PR DESCRIPTION
Adds MIME_TYPE to Encoding for convenience, this is a part of the prometheus spec and reduces the amount of boilerplate a user of measured would have to return data to typical exporters
