### PR TITLE
re-export lasso when enabled so crate users do not have to add it themselves

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -709,7 +709,6 @@ dependencies = [
  "divan",
  "fake 2.9.2",
  "itoa",
- "lasso",
  "measured",
  "prometheus",
  "prometheus-client",

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -24,6 +24,10 @@ pub mod label;
 pub mod metric;
 pub mod text;
 
+/// Reexport of lasso when feature is enabled
+#[cfg(feature = "lasso")]
+pub use lasso;
+
 /// Implement [`FixedCardinalityLabel`] on an `enum`
 ///
 /// # Container attributes
@@ -173,7 +177,7 @@ pub use label::FixedCardinalityLabel;
 /// # Example
 ///
 /// ```
-/// use lasso::{RodeoReader, ThreadedRodeo};
+/// use measured::lasso::{RodeoReader, ThreadedRodeo};
 ///
 /// #[derive(measured::LabelGroup)]
 /// #[label(set = ResponseSet)]
@@ -197,7 +201,7 @@ pub use label::FixedCardinalityLabel;
 /// }
 ///
 /// let set = ResponseSet::new(
-///     ["/foo/bar", "/home"].into_iter().collect::<lasso::Rodeo>().into_reader(),
+///     ["/foo/bar", "/home"].into_iter().collect::<measured::lasso::Rodeo>().into_reader(),
 /// );
 ///
 /// use measured::label::LabelGroupSet as _;

--- a/prometheus-proto/Cargo.toml
+++ b/prometheus-proto/Cargo.toml
@@ -24,7 +24,6 @@ prometheus = { version = "0.14.0", default-features = false, features = ["protob
 prometheus-client = { version = "0.24.0", features = ["protobuf"] }
 rand = { version = "0.8", features = ["small_rng"] }
 ahash = "0.8"
-lasso = { version = "0.7", features = ["multi-threaded"] }
 
 [[bench]]
 name = "encoding"

--- a/prometheus-proto/benches/encoding.rs
+++ b/prometheus-proto/benches/encoding.rs
@@ -1,6 +1,6 @@
 use divan::black_box;
 use divan::Bencher;
-use lasso::{Spur, ThreadedRodeo};
+use measured::lasso::{Spur, ThreadedRodeo};
 use measured::{CounterVec, LabelGroup, MetricGroup};
 use measured_prometheus_protobuf::ProtoEncoder;
 use prometheus::Encoder;


### PR DESCRIPTION
This closes #1
